### PR TITLE
Add missing dependency

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -14,7 +14,6 @@ test/types.js
 node_modules/xcomponent/src/types.js
 [options]
 module.name_mapper='^src\(.*\)$' -> '<PROJECT_ROOT>/src/\1'
-unsafe.enable_getters_and_setters=true
 experimental.const_params=false
 esproposal.export_star_as=enable
 esproposal.decorators=ignore

--- a/README.md
+++ b/README.md
@@ -149,5 +149,5 @@ npm run build
 - Run the tests:
 
   ```bash
-  npm run test
+  npm test
   ```

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "esdoc": "^1.0.4",
     "esdoc-flow-type-plugin": "^1.0.1",
     "esdoc-standard-plugin": "^1.0.0",
+    "flow-bin": "^0.68.0",
     "grumbler-scripts": "^1.0.17"
   }
 }

--- a/test/tests/config.js
+++ b/test/tests/config.js
@@ -1,7 +1,14 @@
 /* @flow */
 
+import assert from 'assert'; // eslint-disable-line import/no-nodejs-modules
+
+/* eslint-disable flowtype/no-weak-types */
+declare var describe: any;
+declare var it: any;
+/* eslint-enable */
+
 describe(`happy cases`, () => {
     it('should successfully create a client instance', () => {
-        // pass
+        assert.ok(true);
     });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,7 +62,7 @@ function getWebpackConfig({ filename, modulename, minify = false, options = {}, 
             rules: [
                 {
                     test:    /\.js$/,
-                    loader: `ifdef-loader?${ qs.encode(PREPROCESSOR_OPTS) }`
+                    loader: `ifdef-loader?${ qs.stringify(PREPROCESSOR_OPTS) }`
                 },
                 {
                     test:   /sinon\.js$/,


### PR DESCRIPTION
This PR does two things.

* Installs a missing flow-bin dependency that was preventing setup
* Simplifies the test command in the readme

When running `npm run flow`, I'm getting this failure:

```
.flowconfig:17 Unsupported option specified! (unsafe.enable_getters_and_setters)
```